### PR TITLE
fix: did not assert if error test cases has no error

### DIFF
--- a/src/original/test/completeTest.js
+++ b/src/original/test/completeTest.js
@@ -80,6 +80,7 @@ contract('eVote', async (accounts) => {
         _merkleProof = usersMerkleTree.getHexProof(accounts[accounts.length-2])            
         try{
             await eVoteInstance.register(data[0].publicKey, data[0].publicKeyProof.a, data[0].publicKeyProof.b, data[0].publicKeyProof.c, _merkleProof, {from:accounts[accounts.length-1], value:web3.utils.toWei("1","ether")})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
            assert(String(err).includes("Invalid Merkle proof"), "error in verifying invalid user")
         }
@@ -93,6 +94,7 @@ contract('eVote', async (accounts) => {
         _merkleProof = usersMerkleTree.getHexProof(accounts[i+1])
         try{
             await eVoteInstance.register(data[i].publicKey, data[i-1].publicKeyProof.a, data[i].publicKeyProof.b, data[i].publicKeyProof.c, _merkleProof, {from:accounts[i+1], value:web3.utils.toWei("1","ether")})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
             assert(String(err).includes("Invalid DL proof"), "error in verifying invalid DL proof")
         }
@@ -119,6 +121,7 @@ contract('eVote', async (accounts) => {
         _merkleProof = usersMerkleTree.getHexProof(accounts[accounts.length-2])            
         try{
             await eVoteInstance.register(data[0].publicKey, data[0].publicKeyProof.a, data[0].publicKeyProof.b, data[0].publicKeyProof.c, _merkleProof, {from:accounts[accounts.length-1], value:web3.utils.toWei("1","ether")})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
            assert(String(err).includes("Max number of voters is reached"), "error in verifying max number of voters")
         }
@@ -137,6 +140,7 @@ contract('eVote', async (accounts) => {
         i = data.length-1;    
         try{
             await eVoteInstance.castVote(data[i-1].encryptedVote, data[i].Idx, data[i].encryptedVoteProof.a, data[i].encryptedVoteProof.b, data[i].encryptedVoteProof.c, {from:accounts[i+1]})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
             assert(String(err).includes("Invalid encrypted vote"), "error in verifying invalid encrypted")
         }    
@@ -163,6 +167,7 @@ contract('eVote', async (accounts) => {
         await mineToBlockNumber(beginTally)        
         try{
             await eVoteInstance.setTally(_tallyingResult + 1, _tallyingProof.a, _tallyingProof.b, _tallyingProof.c,{from:admin});
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
             assert(String(err).includes("Invalid Tallying Result"), "error in verifying Malicious Administrator")
         }

--- a/src/progressivePoseidon/test/completeTest.js
+++ b/src/progressivePoseidon/test/completeTest.js
@@ -80,6 +80,7 @@ contract('eVote', async (accounts) => {
         _merkleProof = usersMerkleTree.getHexProof(accounts[accounts.length-2])            
         try{
             await eVoteInstance.register(data[0].publicKey, data[0].publicKeyProof.a, data[0].publicKeyProof.b, data[0].publicKeyProof.c, _merkleProof, {from:accounts[accounts.length-1], value:web3.utils.toWei("1","ether")})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
            assert(String(err).includes("Invalid Merkle proof"), "error in verifying invalid user")
         }
@@ -93,6 +94,7 @@ contract('eVote', async (accounts) => {
         _merkleProof = usersMerkleTree.getHexProof(accounts[i+1])
         try{
             await eVoteInstance.register(data[i].publicKey, data[i-1].publicKeyProof.a, data[i].publicKeyProof.b, data[i].publicKeyProof.c, _merkleProof, {from:accounts[i+1], value:web3.utils.toWei("1","ether")})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
             assert(String(err).includes("Invalid DL proof"), "error in verifying invalid DL proof")
         }
@@ -123,6 +125,7 @@ contract('eVote', async (accounts) => {
         _merkleProof = usersMerkleTree.getHexProof(accounts[accounts.length-2])            
         try{
             await eVoteInstance.register(data[0].publicKey, data[0].publicKeyProof.a, data[0].publicKeyProof.b, data[0].publicKeyProof.c, _merkleProof, {from:accounts[accounts.length-1], value:web3.utils.toWei("1","ether")})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
            assert(String(err).includes("Max number of voters is reached"), "error in verifying max number of voters")
         }
@@ -141,6 +144,7 @@ contract('eVote', async (accounts) => {
         i = data.length-1;    
         try{
             await eVoteInstance.castVote(data[i-1].encryptedVote, data[i].Idx, data[i].encryptedVoteProof.a, data[i].encryptedVoteProof.b, data[i].encryptedVoteProof.c, {from:accounts[i+1]})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
             assert(String(err).includes("Invalid encrypted vote"), "error in verifying invalid encrypted")
         }    
@@ -170,6 +174,7 @@ contract('eVote', async (accounts) => {
         await mineToBlockNumber(beginTally)        
         try{
             await eVoteInstance.setTally(_tallyingResult + 1, _tallyingProof.a, _tallyingProof.b, _tallyingProof.c,{from:admin});
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
             assert(String(err).includes("Invalid Tallying Result"), "error in verifying Malicious Administrator")
         }

--- a/src/progressiveSha256/test/completeTest.js
+++ b/src/progressiveSha256/test/completeTest.js
@@ -80,6 +80,7 @@ contract('eVote', async (accounts) => {
         _merkleProof = usersMerkleTree.getHexProof(accounts[accounts.length-2])            
         try{
             await eVoteInstance.register(data[0].publicKey, data[0].publicKeyProof.a, data[0].publicKeyProof.b, data[0].publicKeyProof.c, _merkleProof, {from:accounts[accounts.length-1], value:web3.utils.toWei("1","ether")})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
            assert(String(err).includes("Invalid Merkle proof"), "error in verifying invalid user")
         }
@@ -93,6 +94,7 @@ contract('eVote', async (accounts) => {
         _merkleProof = usersMerkleTree.getHexProof(accounts[i+1])
         try{
             await eVoteInstance.register(data[i].publicKey, data[i-1].publicKeyProof.a, data[i].publicKeyProof.b, data[i].publicKeyProof.c, _merkleProof, {from:accounts[i+1], value:web3.utils.toWei("1","ether")})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
             assert(String(err).includes("Invalid DL proof"), "error in verifying invalid DL proof")
         }
@@ -123,6 +125,7 @@ contract('eVote', async (accounts) => {
         _merkleProof = usersMerkleTree.getHexProof(accounts[accounts.length-2])            
         try{
             await eVoteInstance.register(data[0].publicKey, data[0].publicKeyProof.a, data[0].publicKeyProof.b, data[0].publicKeyProof.c, _merkleProof, {from:accounts[accounts.length-1], value:web3.utils.toWei("1","ether")})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
            assert(String(err).includes("Max number of voters is reached"), "error in verifying max number of voters")
         }
@@ -141,6 +144,7 @@ contract('eVote', async (accounts) => {
         i = data.length-1;    
         try{
             await eVoteInstance.castVote(data[i-1].encryptedVote, data[i].Idx, data[i].encryptedVoteProof.a, data[i].encryptedVoteProof.b, data[i].encryptedVoteProof.c, {from:accounts[i+1]})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
             assert(String(err).includes("Invalid encrypted vote"), "error in verifying invalid encrypted")
         }    
@@ -170,6 +174,7 @@ contract('eVote', async (accounts) => {
         await mineToBlockNumber(beginTally)        
         try{
             await eVoteInstance.setTally(_tallyingResult + 1, _tallyingProof.a, _tallyingProof.b, _tallyingProof.c,{from:admin});
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
             assert(String(err).includes("Invalid Tallying Result"), "error in verifying Malicious Administrator")
         }

--- a/src/sha256/test/completeTest.js
+++ b/src/sha256/test/completeTest.js
@@ -80,6 +80,7 @@ contract('eVote', async (accounts) => {
         _merkleProof = usersMerkleTree.getHexProof(accounts[accounts.length-2])            
         try{
             await eVoteInstance.register(data[0].publicKey, data[0].publicKeyProof.a, data[0].publicKeyProof.b, data[0].publicKeyProof.c, _merkleProof, {from:accounts[accounts.length-1], value:web3.utils.toWei("1","ether")})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
            assert(String(err).includes("Invalid Merkle proof"), "error in verifying invalid user")
         }
@@ -93,6 +94,7 @@ contract('eVote', async (accounts) => {
         _merkleProof = usersMerkleTree.getHexProof(accounts[i+1])
         try{
             await eVoteInstance.register(data[i].publicKey, data[i-1].publicKeyProof.a, data[i].publicKeyProof.b, data[i].publicKeyProof.c, _merkleProof, {from:accounts[i+1], value:web3.utils.toWei("1","ether")})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
             assert(String(err).includes("Invalid DL proof"), "error in verifying invalid DL proof")
         }
@@ -119,6 +121,7 @@ contract('eVote', async (accounts) => {
         _merkleProof = usersMerkleTree.getHexProof(accounts[accounts.length-2])            
         try{
             await eVoteInstance.register(data[0].publicKey, data[0].publicKeyProof.a, data[0].publicKeyProof.b, data[0].publicKeyProof.c, _merkleProof, {from:accounts[accounts.length-1], value:web3.utils.toWei("1","ether")})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
            assert(String(err).includes("Max number of voters is reached"), "error in verifying max number of voters")
         }
@@ -137,6 +140,7 @@ contract('eVote', async (accounts) => {
         i = data.length-1;    
         try{
             await eVoteInstance.castVote(data[i-1].encryptedVote, data[i].Idx, data[i].encryptedVoteProof.a, data[i].encryptedVoteProof.b, data[i].encryptedVoteProof.c, {from:accounts[i+1]})
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
             assert(String(err).includes("Invalid encrypted vote"), "error in verifying invalid encrypted")
         }    
@@ -163,6 +167,7 @@ contract('eVote', async (accounts) => {
         await mineToBlockNumber(beginTally)        
         try{
             await eVoteInstance.setTally(_tallyingResult + 1, _tallyingProof.a, _tallyingProof.b, _tallyingProof.c,{from:admin});
+            assert(false, 'Expected error but none was thrown')
         } catch(err) {
             assert(String(err).includes("Invalid Tallying Result"), "error in verifying Malicious Administrator")
         }


### PR DESCRIPTION
Hi, we are a group of student from The University of Hong Kong. We are working on implementing this paper into a usable DApp for our project.

We found that some of the passing test case was not asserted correctly, specifically `Throw an error if elligable user provides invalid DL proof to vote` should not pass. Is the case supposed to be checking for duplicated registration for a same wallet, or duplicate usage of a same public key?

We would try to provide a PR to fix the issue after we confirmed the original intention of the test case, thanks a lot.